### PR TITLE
Move node pr

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Check if version is published
         id: check
+        working-directory: platform/node
         run: |
           currentVersion="$( node -e "console.log(require('./package.json').version)" )"
           isPublished="$( npm view @maplibre/maplibre-gl-native versions --json | jq -c --arg cv "$currentVersion" 'any(. == $cv)' )"
@@ -119,6 +120,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Set up msvc dev cmd (Windows)
@@ -231,21 +233,23 @@ jobs:
 
       - name: Publish X64 Release to Github
         if: matrix.arch == 'x86_64'
+        working-directory: platform/node
         env:
           PUBLISH: true
           BUILDTYPE: RelWithDebInfo
           NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./platform/node/scripts/publish.sh
+          ./scripts/publish.sh
 
       - name: Publish ARM Release to Github
         if: matrix.arch == 'arm64'
+        working-directory: platform/node
         env:
           PUBLISH: true
           BUILDTYPE: RelWithDebInfo
           NODE_PRE_GYP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./platform/node/scripts/publish.sh --target_arch=arm64
+          ./scripts/publish.sh --target_arch=arm64
 
   publish_npm:
     runs-on: ubuntu-latest
@@ -271,6 +275,7 @@ jobs:
         uses: martinbeentjes/npm-get-version-action@v1.3.1
 
       - name: npm ci
+        working-directory: platform/node
         run: npm ci --ignore-scripts
 
       - name: Prepare release
@@ -303,6 +308,7 @@ jobs:
 
       - name: Publish to NPM (release)
         if: ${{ steps.prepare_release.outputs.prerelease == 'false' }}
+        working-directory: platform/node
         run: |
           npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
           npm publish --access public
@@ -311,6 +317,7 @@ jobs:
 
       - name: Publish to NPM (prerelease)
         if: ${{ steps.prepare_release.outputs.prerelease == 'true' }}
+        working-directory: platform/node
         run: |
           npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
           npm publish --tag next --access public

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -273,6 +273,8 @@ jobs:
       - name: Get version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.3.1
+        with:
+          path: platform/node
 
       - name: npm ci
         working-directory: platform/node
@@ -280,6 +282,7 @@ jobs:
 
       - name: Prepare release
         id: prepare_release
+        working-directory: platform/node
         run: |
           RELEASE_TYPE="$(node -e "console.log(require('semver').prerelease('${{ steps.package-version.outputs.current-version }}') ? 'prerelease' : 'regular')")"
           if [[ $RELEASE_TYPE == 'regular' ]]; then
@@ -289,8 +292,9 @@ jobs:
           fi
 
       - name: Extract changelog for version
+        working-directory: platform/node
         run: |
-          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## ${{ steps.package-version.outputs.current-version }}" { p = 1 };' platform/node/CHANGELOG.md > changelog_for_version.md
+          awk '/^##/ { p = 0 }; p == 1 { print }; $0 == "## ${{ steps.package-version.outputs.current-version }}" { p = 1 };' CHANGELOG.md > changelog_for_version.md
           cat changelog_for_version.md
 
       - name: Update Release Notes
@@ -301,7 +305,7 @@ jobs:
         with:
           tag: node-v${{ steps.package-version.outputs.current-version }}
           name: node-v${{ steps.package-version.outputs.current-version }}
-          bodyFile: changelog_for_version.md
+          bodyFile: platform/node/changelog_for_version.md
           allowUpdates: true
           draft: false
           prerelease: ${{ steps.prepare_release.outputs.prerelease }}

--- a/platform/node/CMakeLists.txt
+++ b/platform/node/CMakeLists.txt
@@ -12,6 +12,7 @@ add_node_module(
         47
         48
         51
+        127
 )
 
 if(WIN32)

--- a/platform/node/RELEASE.md
+++ b/platform/node/RELEASE.md
@@ -1,13 +1,17 @@
 # Instructions for making a Node release
 
-1. Change the version number in package.json. on the command line, in the package root directory, run the following command, replacing <update_type> with one of the semantic versioning release types (prerelease, prepatch, preminor, premajor, patch, minor, major):
+1. Open a command prompt to 'platform/node'
+
+cd platform/node
+
+2. Change the version number in package.json. on the command line, in the package root directory, run the following command, replacing <update_type> with one of the semantic versioning release types (prerelease, prepatch, preminor, premajor, patch, minor, major):
 
 npm version <update_type> --preid pre --no-git-tag-version
 
-2. Update the changelog, which can be found in `platform/node/CHANGELOG.md`. The heading must match `## <VERSION>` exactly, or it will not be picked up. For example, for version 5.2.0:
+3. Update the changelog, which can be found in `platform/node/CHANGELOG.md`. The heading must match `## <VERSION>` exactly, or it will not be picked up. For example, for version 5.2.0:
 
 ```
 ## 5.2.0
 ```
 
-3. Commit and push the changes. On push the 'node-release' workflow will automaticlly check if the release has been published on npm. If the release has not yet been published, the workflow will build the node binaries and upload them to a new github release, then publish a new npm release.
+4. Commit and push the changes. On push the 'node-release' workflow will automaticlly check if the release has been published on npm. If the release has not yet been published, the workflow will build the node binaries and upload them to a new github release, then publish a new npm release.


### PR DESCRIPTION
Update release workflow + readme

Testing
I tested these changes in https://github.com/WifiDB/maplibre-native/tree/move-node-test with [@acalcutt/maplibre-gl-native-test](https://www.npmjs.com/package/@acalcutt/maplibre-gl-native-test) and the publish seemed to work to both github and npm. 
https://github.com/WifiDB/maplibre-native/actions/runs/8911170340
https://github.com/WifiDB/maplibre-native/releases/tag/node-v5.4.1-pre.3
https://www.npmjs.com/package/@acalcutt/maplibre-gl-native-test/v/5.4.1-pre.3
