### PR TITLE
Vulkan xcode

### DIFF
--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -77,9 +77,12 @@ private:
     static void onMouseClick(GLFWwindow *window, int button, int action, int modifiers);
     static void onMouseMove(GLFWwindow *window, double x, double y);
     static void onWindowFocus(GLFWwindow *window, int focused);
+    static void onWindowRefresh(GLFWwindow *window);
 
     // Internal
     void report(float duration);
+
+    void render();
 
     mbgl::Color makeRandomColor() const;
     mbgl::Point<double> makeRandomPoint() const;

--- a/src/mbgl/shaders/vulkan/shader_program.cpp
+++ b/src/mbgl/shaders/vulkan/shader_program.cpp
@@ -54,7 +54,7 @@ ShaderProgram::ShaderProgram(shaders::BuiltIn shaderID,
 
         const auto preamble = defineStr + "\n" + prelude;
         const char* shaderData = data.data();
-        const int shaderDataSize = data.size();
+        const int shaderDataSize = static_cast<int>(data.size());
 
         glslShader.setPreamble(preamble.c_str());
         glslShader.setStringsWithLengths(&shaderData, &shaderDataSize, 1);

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -207,9 +207,11 @@ void Context::beginFrame() {
             } else if (acquireImageResult.result == vk::Result::eSuboptimalKHR) {
                 renderableResource.setAcquiredImageIndex(acquireImageResult.value);
                 // TODO implement pre-rotation transform for surface orientation
-                // requestSurfaceUpdate();
-                // beginFrame();
-                // return;
+#if defined(__APPLE__)
+                requestSurfaceUpdate();
+                beginFrame();
+                return;
+#endif
             }
 
         } catch (const vk::OutOfDateKHRError& e) {
@@ -271,7 +273,9 @@ void Context::submitFrame() {
             const vk::Result presentResult = presentQueue.presentKHR(presentInfo);
             if (presentResult == vk::Result::eSuboptimalKHR) {
                 // TODO implement pre-rotation transform for surface orientation
-                // requestSurfaceUpdate();
+#if defined(__APPLE__)
+                requestSurfaceUpdate();
+#endif
             }
         } catch (const vk::OutOfDateKHRError& e) {
             requestSurfaceUpdate();

--- a/src/mbgl/vulkan/context.cpp
+++ b/src/mbgl/vulkan/context.cpp
@@ -438,13 +438,13 @@ bool Context::renderTileClippingMasks(gfx::RenderPass& renderPass,
         clipping.pipelineInfo.inputBindings.push_back(
             vk::VertexInputBindingDescription()
                 .setBinding(0)
-                .setStride(VertexAttribute::getStrideOf(ShaderClass::attributes[0].dataType))
+                .setStride(static_cast<uint32_t>(VertexAttribute::getStrideOf(ShaderClass::attributes[0].dataType)))
                 .setInputRate(vk::VertexInputRate::eVertex));
 
         clipping.pipelineInfo.inputAttributes.push_back(
             vk::VertexInputAttributeDescription()
                 .setBinding(0)
-                .setLocation(ShaderClass::attributes[0].index)
+                .setLocation(static_cast<uint32_t>(ShaderClass::attributes[0].index))
                 .setFormat(PipelineInfo::vulkanFormat(ShaderClass::attributes[0].dataType)));
     }
 
@@ -521,7 +521,7 @@ const vk::UniqueDescriptorSetLayout& Context::getUniformDescriptorSetLayout() {
 
         for (size_t i = 0; i < shaders::maxUBOCountPerShader; ++i) {
             bindings.push_back(vk::DescriptorSetLayoutBinding()
-                                   .setBinding(i)
+                                   .setBinding(static_cast<uint32_t>(i))
                                    .setStageFlags(stageFlags)
                                    .setDescriptorType(vk::DescriptorType::eUniformBuffer)
                                    .setDescriptorCount(1));
@@ -542,7 +542,7 @@ const vk::UniqueDescriptorSetLayout& Context::getImageDescriptorSetLayout() {
 
         for (size_t i = 0; i < shaders::maxTextureCountPerShader; ++i) {
             bindings.push_back(vk::DescriptorSetLayoutBinding()
-                                   .setBinding(i)
+                                   .setBinding(static_cast<uint32_t>(i))
                                    .setStageFlags(vk::ShaderStageFlagBits::eFragment)
                                    .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
                                    .setDescriptorCount(1));

--- a/src/mbgl/vulkan/drawable.cpp
+++ b/src/mbgl/vulkan/drawable.cpp
@@ -239,7 +239,7 @@ void Drawable::draw(PaintParameters& parameters) const {
 
     impl->pipelineInfo.setRenderable(renderPass_.getDescriptor().renderable);
 
-    const uint32_t instances = instanceAttributes ? instanceAttributes->getMaxCount() : 1;
+    const auto instances = instanceAttributes ? instanceAttributes->getMaxCount() : 1;
 
     for (const auto& seg : impl->segments) {
         const auto& segment = seg->getSegment();
@@ -253,9 +253,16 @@ void Drawable::draw(PaintParameters& parameters) const {
         commandBuffer->bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline.get());
 
         if (segment.indexLength) {
-            commandBuffer->drawIndexed(segment.indexLength, instances, segment.indexOffset, segment.vertexOffset, 0);
+            commandBuffer->drawIndexed(static_cast<uint32_t>(segment.indexLength),
+                                       static_cast<uint32_t>(instances),
+                                       static_cast<uint32_t>(segment.indexOffset),
+                                       static_cast<int32_t>(segment.vertexOffset),
+                                       0);
         } else {
-            commandBuffer->draw(segment.vertexLength, instances, segment.vertexOffset, 0);
+            commandBuffer->draw(static_cast<uint32_t>(segment.vertexLength),
+                                static_cast<uint32_t>(instances),
+                                static_cast<uint32_t>(segment.vertexOffset),
+                                0);
         }
 
         context.renderingStats().numDrawCalls++;
@@ -314,7 +321,7 @@ void Drawable::buildVulkanInputBindings() noexcept {
             const auto& buffer = vertexBuffer->get();
 
             const auto& buffIt = std::find(uniqueBuffers.begin(), uniqueBuffers.end(), binding->vertexBufferResource);
-            uint32_t bindingIndex = 0;
+            std::size_t bindingIndex = 0;
 
             if (buffIt == uniqueBuffers.end()) {
                 bindingIndex = impl->pipelineInfo.inputBindings.size();
@@ -323,7 +330,7 @@ void Drawable::buildVulkanInputBindings() noexcept {
 
                 // add new buffer binding
                 impl->pipelineInfo.inputBindings.push_back(vk::VertexInputBindingDescription()
-                                                               .setBinding(bindingIndex)
+                                                               .setBinding(static_cast<uint32_t>(bindingIndex))
                                                                .setStride(binding->vertexStride)
                                                                .setInputRate(inputRate));
 
@@ -335,8 +342,8 @@ void Drawable::buildVulkanInputBindings() noexcept {
 
             impl->pipelineInfo.inputAttributes.push_back(
                 vk::VertexInputAttributeDescription()
-                    .setBinding(bindingIndex)
-                    .setLocation(i)
+                    .setBinding(static_cast<uint32_t>(bindingIndex))
+                    .setLocation(static_cast<uint32_t>(i))
                     .setFormat(PipelineInfo::vulkanFormat(binding->attribute.dataType))
                     .setOffset(binding->attribute.offset));
         }
@@ -401,7 +408,7 @@ bool Drawable::bindDescriptors(CommandEncoder& encoder) const noexcept {
                                                 .setBufferInfo(descriptorBufferInfo)
                                                 .setDescriptorCount(1)
                                                 .setDescriptorType(vk::DescriptorType::eUniformBuffer)
-                                                .setDstBinding(id)
+                                                .setDstBinding(static_cast<uint32_t>(id))
                                                 .setDstSet(uniformDescriptorSet);
 
             device->updateDescriptorSets(writeDescriptorSet, nullptr);
@@ -430,7 +437,7 @@ bool Drawable::bindDescriptors(CommandEncoder& encoder) const noexcept {
                                                 .setImageInfo(descriptorImageInfo)
                                                 .setDescriptorCount(1)
                                                 .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
-                                                .setDstBinding(id)
+                                                .setDstBinding(static_cast<uint32_t>(id))
                                                 .setDstSet(imageDescriptorSet);
 
             device->updateDescriptorSets(writeDescriptorSet, nullptr);

--- a/src/mbgl/vulkan/texture2d.cpp
+++ b/src/mbgl/vulkan/texture2d.cpp
@@ -496,7 +496,7 @@ std::shared_ptr<PremultipliedImage> Texture2D::readImage() {
     if (imageSize == layout.arrayPitch) {
         memcpy(imageData->data.get(), mappedData, imageSize);
     } else {
-        uint32_t rowSize = size.width * getPixelStride();
+        auto rowSize = static_cast<uint32_t>(size.width * getPixelStride());
         for (uint32_t i = 0; i < size.height; ++i) {
             memcpy(imageData->data.get() + rowSize * i, mappedData + layout.rowPitch * i, rowSize);
         }


### PR DESCRIPTION
Fixes some errors seen when building with Xcode.
Work around a MoltenVK problem.
Adds continuous resize for this platform/backend combination.

`cmake -D MLN_WITH_VULKAN=ON -DMLN_WITH_OPENGL=OFF -DMLN_DRAWABLE_RENDERER=ON -B build -S . -GXcode`