### PR TITLE
tweaks

### DIFF
--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -55,13 +55,21 @@ public:
 
     /// Dynamically cast this source to the given subtype.
     template <class T>
+    requires (std::is_base_of_v<Source, T>)
     T* as() {
-        return is<T>() ? reinterpret_cast<T*>(this) : nullptr;
+        if constexpr (std::is_same_v<T, Source>) {
+            return this;
+        }
+        return is<T>() ? static_cast<T*>(this) : nullptr;
     }
 
     template <class T>
+    requires (std::is_base_of_v<Source, T>)
     const T* as() const {
-        return is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
+        if constexpr (std::is_same_v<T, Source>) {
+            return this;
+        }
+        return is<T>() ? static_cast<const T*>(this) : nullptr;
     }
 
     SourceType getType() const;

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/custom_geometry_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/custom_geometry_source.cpp
@@ -141,19 +141,19 @@ void CustomGeometrySource::setTileData(
 
     // Update the core source if not cancelled
     if (!isCancelled(z, x, y)) {
-        source->get().as<mbgl::style::CustomGeometrySource>()->CustomGeometrySource::setTileData(
+        getSource<mbgl::style::CustomGeometrySource>().CustomGeometrySource::setTileData(
             CanonicalTileID(z, x, y), GeoJSON(geometry));
     }
 }
 
 void CustomGeometrySource::invalidateTile(jni::JNIEnv&, jni::jint z, jni::jint x, jni::jint y) {
-    source->get().as<mbgl::style::CustomGeometrySource>()->CustomGeometrySource::invalidateTile(
+    getSource<mbgl::style::CustomGeometrySource>().CustomGeometrySource::invalidateTile(
         CanonicalTileID(z, x, y));
 }
 
 void CustomGeometrySource::invalidateBounds(jni::JNIEnv& env, const jni::Object<LatLngBounds>& jBounds) {
     auto bounds = LatLngBounds::getLatLngBounds(env, jBounds);
-    source->get().as<mbgl::style::CustomGeometrySource>()->CustomGeometrySource::invalidateRegion(bounds);
+    getSource<mbgl::style::CustomGeometrySource>().CustomGeometrySource::invalidateRegion(bounds);
 }
 
 jni::Local<jni::Array<jni::Object<geojson::Feature>>> CustomGeometrySource::querySourceFeatures(
@@ -163,7 +163,7 @@ jni::Local<jni::Array<jni::Object<geojson::Feature>>> CustomGeometrySource::quer
 
     std::vector<mbgl::Feature> features;
     if (rendererFrontend) {
-        features = rendererFrontend->querySourceFeatures(source->get().getID(), {{}, toFilter(env, jfilter)});
+        features = rendererFrontend->querySourceFeatures(getSource().getID(), {{}, toFilter(env, jfilter)});
     }
     return Feature::convert(env, features);
 }

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/geojson_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/geojson_source.cpp
@@ -50,12 +50,12 @@ GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, const jni::String& sourceId, cons
              std::make_unique<mbgl::style::GeoJSONSource>(jni::Make<std::string>(env, sourceId),
                                                           convertGeoJSONOptions(env, options))),
       converter(std::make_unique<Actor<FeatureConverter>>(
-          Scheduler::GetBackground(), source->get().as<style::GeoJSONSource>()->impl().getOptions())) {}
+          Scheduler::GetBackground(), getSource<style::GeoJSONSource>().impl().getOptions())) {}
 
 GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, mbgl::style::Source& coreSource, AndroidRendererFrontend* frontend)
     : Source(env, coreSource, createJavaPeer(env), frontend),
       converter(std::make_unique<Actor<FeatureConverter>>(
-          Scheduler::GetBackground(), source->get().as<style::GeoJSONSource>()->impl().getOptions())) {}
+          Scheduler::GetBackground(), getSource<style::GeoJSONSource>().impl().getOptions())) {}
 
 GeoJSONSource::~GeoJSONSource() = default;
 
@@ -83,11 +83,11 @@ void GeoJSONSource::setGeometry(jni::JNIEnv& env, const jni::Object<geojson::Geo
 
 void GeoJSONSource::setURL(jni::JNIEnv& env, const jni::String& url) {
     // Update the core source
-    source->get().as<style::GeoJSONSource>()->setURL(jni::Make<std::string>(env, url));
+    getSource<style::GeoJSONSource>().setURL(jni::Make<std::string>(env, url));
 }
 
 jni::Local<jni::String> GeoJSONSource::getURL(jni::JNIEnv& env) {
-    std::optional<std::string> url = source->get().as<style::GeoJSONSource>()->getURL();
+    std::optional<std::string> url = getSource<style::GeoJSONSource>().getURL();
     return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
 }
 
@@ -98,7 +98,7 @@ jni::Local<jni::Array<jni::Object<geojson::Feature>>> GeoJSONSource::querySource
 
     std::vector<mbgl::Feature> features;
     if (rendererFrontend) {
-        features = rendererFrontend->querySourceFeatures(source->get().getID(), {{}, toFilter(env, jfilter)});
+        features = rendererFrontend->querySourceFeatures(getSource().getID(), {{}, toFilter(env, jfilter)});
     }
     return Feature::convert(env, features);
 }
@@ -112,7 +112,7 @@ jni::Local<jni::Array<jni::Object<geojson::Feature>>> GeoJSONSource::getClusterC
         mbgl::Feature _feature = Feature::convert(env, feature);
         _feature.properties["cluster_id"] = static_cast<uint64_t>(_feature.properties["cluster_id"].get<double>());
         const auto featureExtension = rendererFrontend->queryFeatureExtensions(
-            source->get().getID(), _feature, "supercluster", "children", {});
+                getSource().getID(), _feature, "supercluster", "children", {});
         if (featureExtension.is<mbgl::FeatureCollection>()) {
             return Feature::convert(env, featureExtension.get<mbgl::FeatureCollection>());
         }
@@ -131,7 +131,7 @@ jni::Local<jni::Array<jni::Object<geojson::Feature>>> GeoJSONSource::getClusterL
         const std::map<std::string, mbgl::Value> options = {{"limit", static_cast<uint64_t>(limit)},
                                                             {"offset", static_cast<uint64_t>(offset)}};
         auto featureExtension = rendererFrontend->queryFeatureExtensions(
-            source->get().getID(), _feature, "supercluster", "leaves", options);
+                getSource().getID(), _feature, "supercluster", "leaves", options);
         if (featureExtension.is<mbgl::FeatureCollection>()) {
             return Feature::convert(env, featureExtension.get<mbgl::FeatureCollection>());
         }
@@ -148,7 +148,7 @@ jint GeoJSONSource::getClusterExpansionZoom(jni::JNIEnv& env, const jni::Object<
         mbgl::Feature _feature = Feature::convert(env, feature);
         _feature.properties["cluster_id"] = static_cast<uint64_t>(_feature.properties["cluster_id"].get<double>());
         auto featureExtension = rendererFrontend->queryFeatureExtensions(
-            source->get().getID(), _feature, "supercluster", "expansion-zoom", {});
+                getSource().getID(), _feature, "supercluster", "expansion-zoom", {});
         if (featureExtension.is<mbgl::Value>()) {
             auto value = featureExtension.get<mbgl::Value>();
             if (value.is<uint64_t>()) {
@@ -183,7 +183,7 @@ void GeoJSONSource::setAsync(Update::Converter converterFn) {
         std::make_unique<Actor<GeoJSONDataCallback>>(
             *Scheduler::GetCurrent(),
             [awaitingUpdateWeak = std::weak_ptr(awaitingUpdate),
-             sourceWeak = std::weak_ptr(source),
+             sourceWeak = getWeakSource(),
              updateWeak = std::weak_ptr(update)](std::shared_ptr<style::GeoJSONData> geoJSONData) {
                 auto awaitingUpdate = awaitingUpdateWeak.lock();
                 auto source = sourceWeak.lock();
@@ -194,7 +194,7 @@ void GeoJSONSource::setAsync(Update::Converter converterFn) {
                 android::UniqueEnv _env = android::AttachEnv();
 
                 // Update the core source
-                source->get().as<mbgl::style::GeoJSONSource>()->setGeoJSONData(std::move(geoJSONData));
+                source->get().as<style::GeoJSONSource>()->setGeoJSONData(std::move(geoJSONData));
 
                 // if there is an awaiting update, execute it, otherwise, release resources
                 if (awaitingUpdate) {

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/image_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/image_source.cpp
@@ -29,20 +29,20 @@ ImageSource::~ImageSource() = default;
 
 void ImageSource::setURL(jni::JNIEnv& env, const jni::String& url) {
     // Update the core source
-    source->get().as<mbgl::style::ImageSource>()->ImageSource::setURL(jni::Make<std::string>(env, url));
+    getSource<mbgl::style::ImageSource>().ImageSource::setURL(jni::Make<std::string>(env, url));
 }
 
 jni::Local<jni::String> ImageSource::getURL(jni::JNIEnv& env) {
-    std::optional<std::string> url = source->get().as<mbgl::style::ImageSource>()->ImageSource::getURL();
+    std::optional<std::string> url = getSource<mbgl::style::ImageSource>().ImageSource::getURL();
     return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
 }
 
 void ImageSource::setImage(jni::JNIEnv& env, const jni::Object<Bitmap>& bitmap) {
-    source->get().as<mbgl::style::ImageSource>()->setImage(Bitmap::GetImage(env, bitmap));
+    getSource<mbgl::style::ImageSource>().setImage(Bitmap::GetImage(env, bitmap));
 }
 
 void ImageSource::setCoordinates(jni::JNIEnv& env, const jni::Object<LatLngQuad>& coordinatesObject) {
-    source->get().as<mbgl::style::ImageSource>()->setCoordinates(LatLngQuad::getLatLngArray(env, coordinatesObject));
+    getSource<mbgl::style::ImageSource>().setCoordinates(LatLngQuad::getLatLngArray(env, coordinatesObject));
 }
 
 jni::Local<jni::Object<Source>> ImageSource::createJavaPeer(jni::JNIEnv& env) {

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/raster_dem_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/raster_dem_source.cpp
@@ -26,7 +26,7 @@ RasterDEMSource::RasterDEMSource(jni::JNIEnv& env, mbgl::style::Source& coreSour
 RasterDEMSource::~RasterDEMSource() = default;
 
 jni::Local<jni::String> RasterDEMSource::getURL(jni::JNIEnv& env) {
-    std::optional<std::string> url = source->get().as<mbgl::style::RasterDEMSource>()->RasterDEMSource::getURL();
+    auto url = getSource<mbgl::style::RasterDEMSource>().RasterDEMSource::getURL();
     return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
 }
 

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/raster_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/raster_source.cpp
@@ -25,7 +25,7 @@ RasterSource::RasterSource(jni::JNIEnv& env, mbgl::style::Source& coreSource, An
 RasterSource::~RasterSource() = default;
 
 jni::Local<jni::String> RasterSource::getURL(jni::JNIEnv& env) {
-    std::optional<std::string> url = source->get().as<mbgl::style::RasterSource>()->RasterSource::getURL();
+    auto url = getSource<mbgl::style::RasterSource>().RasterSource::getURL();
     return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
 }
 

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/source.hpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/source.hpp
@@ -64,12 +64,19 @@ public:
     jni::Local<jni::Long> getMinimumTileUpdateInterval(JNIEnv&);
 
 protected:
+    template <typename T = style::Source>
+    T& getSource() { return *ownedSource->as<T>(); }
+
+    std::weak_ptr<std::reference_wrapper<style::Source>> getWeakSource() const { return source; }
+
+private:
     // Set on newly created sources until added to the map.
     std::unique_ptr<mbgl::style::Source> ownedSource;
 
     // Reference that is valid at all times.
     std::shared_ptr<std::reference_wrapper<mbgl::style::Source>> source;
 
+protected:
     // Set when the source is added to a map.
     jni::Global<jni::Object<Source>> javaPeer;
 

--- a/platform/android/MapLibreAndroid/src/cpp/style/sources/vector_source.cpp
+++ b/platform/android/MapLibreAndroid/src/cpp/style/sources/vector_source.cpp
@@ -31,7 +31,7 @@ VectorSource::VectorSource(jni::JNIEnv& env, mbgl::style::Source& coreSource, An
 VectorSource::~VectorSource() = default;
 
 jni::Local<jni::String> VectorSource::getURL(jni::JNIEnv& env) {
-    std::optional<std::string> url = source->get().as<mbgl::style::VectorSource>()->VectorSource::getURL();
+    std::optional<std::string> url = getSource<mbgl::style::VectorSource>().VectorSource::getURL();
     return url ? jni::Make<jni::String>(env, *url) : jni::Local<jni::String>();
 }
 
@@ -42,7 +42,7 @@ jni::Local<jni::Array<jni::Object<geojson::Feature>>> VectorSource::querySourceF
 
     std::vector<mbgl::Feature> features;
     if (rendererFrontend) {
-        features = rendererFrontend->querySourceFeatures(source->get().getID(),
+        features = rendererFrontend->querySourceFeatures(getSource().getID(),
                                                          {toVector(env, jSourceLayerIds), toFilter(env, jfilter)});
     }
     return Feature::convert(env, features);


### PR DESCRIPTION
Protect source `shared_ptr` from inadvertent use, simplify use of the `unique_ptr`.  Use safer cast in `Source::as`.